### PR TITLE
fix 'cfg_atsha204a_i2c_default' define error

### DIFF
--- a/python/examples/common.py
+++ b/python/examples/common.py
@@ -5,7 +5,7 @@ import base64
 import sys
 
 # Maps common name to the specific name used internally
-atca_names_map = {'i2c': 'i2c', 'hid': 'kithid', 'sha': 'sha204', 'ecc': 'eccx08'}
+atca_names_map = {'i2c': 'i2c', 'hid': 'kithid', 'sha': 'sha20x', 'ecc': 'eccx08'}
 
 try:
     FileNotFoundError


### PR DESCRIPTION
for cryptoauthlib version Release v3.1.0 (20200205), "cfg_atsha204a_i2c_default" is not defined. Instead right now it is defined as "cfg_atsha20xa_i2c_default".

I retain no copyright to these changes and they may be freely redistributed under the existing cryptoauthtools license