### PR TITLE
Do not set atcai2c.bus = 1 when bus is specified

### DIFF
--- a/python/examples/config.py
+++ b/python/examples/config.py
@@ -80,8 +80,9 @@ def configure_device(iface='hid', device='ecc', i2c_addr=None, keygen=True, **kw
             setattr(icfg, k, int(v, 16))
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS

--- a/python/examples/create_csr.py
+++ b/python/examples/create_csr.py
@@ -101,8 +101,9 @@ def info(iface='hid', device='ecc', **kwargs):
             setattr(icfg, k, int(v, 16))
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS

--- a/python/examples/ecdh.py
+++ b/python/examples/ecdh.py
@@ -48,8 +48,9 @@ def ECDH(slot, iface='hid', **kwargs):
 
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS

--- a/python/examples/info.py
+++ b/python/examples/info.py
@@ -38,8 +38,9 @@ def info(iface='hid', device='ecc', **kwargs):
             setattr(icfg, k, int(v, 16))
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS

--- a/python/examples/key_attestation.py
+++ b/python/examples/key_attestation.py
@@ -58,8 +58,9 @@ def init_device(iface='hid', **kwargs):
             setattr(icfg, k, int(v, 16))
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS

--- a/python/examples/read_write.py
+++ b/python/examples/read_write.py
@@ -57,8 +57,9 @@ def read_write(iface='hid', device='ecc', **kwargs):
             setattr(icfg, k, int(v, 16))
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS

--- a/python/examples/sign_verify.py
+++ b/python/examples/sign_verify.py
@@ -50,8 +50,9 @@ def init_device(iface='hid', slot=0, **kwargs):
             setattr(icfg, k, int(v, 16))
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS

--- a/python/examples/tng_certs.py
+++ b/python/examples/tng_certs.py
@@ -52,8 +52,9 @@ def init_device(iface='hid', **kwargs):
             setattr(icfg, k, int(v, 16))
 
     # Basic Raspberry Pi I2C check
-    if 'i2c' == iface and check_if_rpi():
-        cfg.cfg.atcai2c.bus = 1
+    if 'bus' not in kwargs:
+        if 'i2c' == iface and check_if_rpi():
+            cfg.cfg.atcai2c.bus = 1
 
     # Initialize the stack
     assert atcab_init(cfg) == ATCA_SUCCESS


### PR DESCRIPTION
I want to use these scripts for Seeed reTerminal.
ATECC608A is connected a Compute Module 4 via I2C bus 3.

Specifying a bus with the -p option does not work.

```
$ python3 ~/cryptoauthtools/python/examples/info.py -i i2c -p bus=3
Traceback (most recent call last):
  File "/home/pi/cryptoauthtools/python/examples/info.py", line 93, in <module>
    info(args.iface, args.device, **parse_interface_params(args.params))
  File "/home/pi/cryptoauthtools/python/examples/info.py", line 45, in info
    assert atcab_init(cfg) == ATCA_SUCCESS
AssertionError
```

This is a pull request that disables this logic when you specify bus with the -p option.

https://github.com/MicrochipTech/cryptoauthtools/blob/e44a4997dd669524a70c52ae663835978c8b1641/python/examples/info.py#L42

