### PR TITLE
Fixed typo from cryptoauthlib

### DIFF
--- a/python/examples/read_write.py
+++ b/python/examples/read_write.py
@@ -88,7 +88,7 @@ def read_write(iface='hid', device='ecc', **kwargs):
     elif dev_name == 'ATECC508A':
         config = Atecc508aConfig.from_buffer(config_data)
     elif dev_name == 'ATECC608A':
-        config = Atecc608aConfig.from_buffer(config_data)
+        config = Atecc608Config.from_buffer(config_data)
     else:
         raise ValueError('Unsupported device {}'.format(dev_name))
 


### PR DESCRIPTION
The ATECC608a Config Zone Definition does not exist in cryptoauthlib, the correct usage is ATECC608. 